### PR TITLE
Support Theme Inheritance

### DIFF
--- a/caja-extensions/caja-folder-color-switcher.py
+++ b/caja-extensions/caja-folder-color-switcher.py
@@ -163,6 +163,9 @@ class Theme(object):
     def find_folder_icon(self, color, directory=None):
         logger.debug("Trying to find icon for directory %s in %s for theme %s" % (directory, color, self))
         relevant_ancestor = self.get_ancestor_defining_folder_svg(directory)
+        if not relevant_ancestor:
+            logger.warning("Could not find ancestor defining SVG")
+            return None
         logger.debug("Ancestor defining SVG is %s" % relevant_ancestor)
         colored_theme = relevant_ancestor.sibling(color)
         icon_path = colored_theme.get_folder_icon_path(directory)

--- a/caja-extensions/caja-folder-color-switcher.py
+++ b/caja-extensions/caja-folder-color-switcher.py
@@ -6,12 +6,12 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # Folder Color is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with Folder Color; if not, see http://www.gnu.org/licenses
 # for more information.
@@ -235,7 +235,7 @@ class ChangeFolderColorBase:
 
 
 class ChangeColorFolder(ChangeFolderColorBase, GObject.GObject, Caja.MenuProvider):
-    def __init__(self):                
+    def __init__(self):
         self.SEPARATOR = u'\u2015' * 4
         self.settings = Gio.Settings.new("org.mate.interface")
         self.settings.connect("changed::icon-theme", self.on_theme_changed)

--- a/caja-extensions/caja-folder-color-switcher.py
+++ b/caja-extensions/caja-folder-color-switcher.py
@@ -55,7 +55,7 @@ COLORS = [
            ]
 
 
-class Theme:
+class Theme(object):
     KNOWN_DIRECTORIES = {
         GLib.get_user_special_dir(GLib.USER_DIRECTORY_DESKTOP): 'user-desktop.svg',
         GLib.get_user_special_dir(GLib.USER_DIRECTORY_DOCUMENTS): 'folder-documents.svg',
@@ -196,7 +196,7 @@ class Theme:
             return Theme.KNOWN_THEMES.get(self.base_name)
 
 
-class ChangeFolderColorBase:
+class ChangeFolderColorBase(object):
     def update_theme(self, theme_str):
         logger.info("Current icon theme: %s", theme_str)
         self.theme = Theme.from_theme_name(theme_str)

--- a/nemo-extensions/nemo-folder-color-switcher.py
+++ b/nemo-extensions/nemo-folder-color-switcher.py
@@ -168,6 +168,9 @@ class Theme(object):
     def find_folder_icon(self, color, directory=None):
         logger.debug("Trying to find icon for directory %s in %s for theme %s" % (directory, color, self))
         relevant_ancestor = self.get_ancestor_defining_folder_svg(directory)
+        if not relevant_ancestor:
+            logger.warning("Could not find ancestor defining SVG")
+            return None
         logger.debug("Ancestor defining SVG is %s" % relevant_ancestor)
         colored_theme = relevant_ancestor.sibling(color)
         icon_path = colored_theme.get_folder_icon_path(directory)

--- a/nemo-extensions/nemo-folder-color-switcher.py
+++ b/nemo-extensions/nemo-folder-color-switcher.py
@@ -6,17 +6,17 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # Folder Color is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with Folder Color; if not, see http://www.gnu.org/licenses
 # for more information.
 
-import os, urllib, gettext, locale, collections, urlparse
+import os, urllib, gettext, locale, urlparse
 import subprocess
 from gi.repository import Nemo, GObject, Gio, GLib, Gtk, Gdk, GdkPixbuf, cairo
 _ = gettext.gettext
@@ -28,7 +28,7 @@ signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 # LOGGING setup:
 # By default, we are only logging messages of level WARNING or higher.
-# For debugging purposes it is useful to run Nemo with
+# For debugging purposes it is useful to run Nemo/Caja with
 # LOG_FOLDER_COLOR_SWITCHER=10 (DEBUG).
 import logging
 log_level = os.getenv('LOG_FOLDER_COLOR_SWITCHER', None)
@@ -40,22 +40,22 @@ logging.basicConfig(level=log_level)
 logger = logging.getLogger(__name__)
 
 
-COLORS = [ 
+COLORS = [
             'Sand',
             'Beige',
             'Yellow',
             'Orange',
             'Brown',
             'Red',
-            'Purple', 
-            'Pink', 
-            'Blue',            
+            'Purple',
+            'Pink',
+            'Blue',
             'Cyan',
             'Aqua',
             'Teal',
             'Green',
             'White',
-            'Grey',            
+            'Grey',
             'Black'
            ]
 
@@ -247,7 +247,7 @@ css_colors = """
     border-color: transparent;
 }
 
-.folder-color-switcher-button:hover {    
+.folder-color-switcher-button:hover {
     border-color: #9c9c9c;
 }
 
@@ -369,10 +369,10 @@ class FolderColorButton(Nemo.SimpleButton):
         else:
             c.add_class("folder-color-switcher-button")
             image = Gtk.Image()
-            image.set_from_file("/usr/share/icons/hicolor/22x22/apps/folder-color-switcher-%s.png" % color.lower())   
-            self.set_image(image)               
+            image.set_from_file("/usr/share/icons/hicolor/22x22/apps/folder-color-switcher-%s.png" % color.lower())
+            self.set_image(image)
 
-    def on_draw(self, widget, cr):        
+    def on_draw(self, widget, cr):
         width = widget.get_allocated_width ();
         height = widget.get_allocated_height ();
 
@@ -401,5 +401,3 @@ class FolderColorButton(Nemo.SimpleButton):
         cr.restore()
 
         return False
-
-

--- a/nemo-extensions/nemo-folder-color-switcher.py
+++ b/nemo-extensions/nemo-folder-color-switcher.py
@@ -60,7 +60,7 @@ COLORS = [
            ]
 
 
-class Theme:
+class Theme(object):
     KNOWN_DIRECTORIES = {
         GLib.get_user_special_dir(GLib.USER_DIRECTORY_DESKTOP): 'user-desktop.svg',
         GLib.get_user_special_dir(GLib.USER_DIRECTORY_DOCUMENTS): 'folder-documents.svg',
@@ -201,7 +201,7 @@ class Theme:
             return Theme.KNOWN_THEMES.get(self.base_name)
 
 
-class ChangeFolderColorBase:
+class ChangeFolderColorBase(object):
     def update_theme(self, theme_str):
         logger.info("Current icon theme: %s", theme_str)
         self.theme = Theme.from_theme_name(theme_str)

--- a/nemo-extensions/nemo-folder-color-switcher.py
+++ b/nemo-extensions/nemo-folder-color-switcher.py
@@ -25,6 +25,21 @@ P_ = gettext.ngettext
 import signal
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
+
+# LOGGING setup:
+# By default, we are only logging messages of level WARNING or higher.
+# For debugging purposes it is useful to run Nemo with
+# LOG_FOLDER_COLOR_SWITCHER=10 (DEBUG).
+import logging
+log_level = os.getenv('LOG_FOLDER_COLOR_SWITCHER', None)
+if not log_level:
+    log_level = logging.WARNING
+else:
+    log_level = int(log_level)
+logging.basicConfig(level=log_level)
+logger = logging.getLogger(__name__)
+
+
 KNOWN_COLORS = {'Mint-X': 'Green',
                 'Mint-X-Dark': 'Green',
                 'Rave-X-CX': 'Beige',
@@ -83,7 +98,7 @@ Gtk.StyleContext.add_provider_for_screen (screen, provider, 600) # GTK_STYLE_PRO
 
 class ChangeColorFolder(GObject.GObject, Nemo.MenuProvider):
     def __init__(self):
-        print "Initializing folder-color-switcher extension..."
+        logger.info("Initializing folder-color-switcher extension...")
         self.SEPARATOR = u'\u2015' * 4
         self.DEFAULT_FOLDERS = self.get_default_folders()   
         self.settings = Gio.Settings.new("org.cinnamon.desktop.interface")
@@ -93,6 +108,7 @@ class ChangeColorFolder(GObject.GObject, Nemo.MenuProvider):
     
     def get_theme(self):
         self.theme =  self.settings.get_string("icon-theme")
+        logger.info("Current icon theme: %s", self.theme)
         self.color = None
         self.base_theme = True
         self.base_color = None
@@ -103,6 +119,7 @@ class ChangeColorFolder(GObject.GObject, Nemo.MenuProvider):
                 self.base_theme = False
         if not self.base_theme and KNOWN_COLORS.has_key(self.theme):
             self.base_color = KNOWN_COLORS[self.theme]
+        logger.debug('base_color is now %s', self.base_color)
 
     def on_theme_changed(self, settings, key):
         self.get_theme()


### PR DESCRIPTION
Currently, folder-color-switcher will not work with the Mint-X-Dark color theme. It will try to find colored folder icons in Mint-X-Dark-[COLOR], which does not exist. However, Mint-X-Dark does not define a custom folder icon. Therefore, it is safe to use the colored versions of the (normal) Mint-X theme, from which Mint-X-Dark inherits.

Instead of fixing this issue directly, I thought it might be useful to implemented support for icon theme inheritance (as defined by the `Inherits` line in a theme's `index.theme`) in general, as it could make the extensions work with other icon themes as well.

Here is a quick overview of my changes:
- Implement logging which can be controlled using an environment variable. (This is not part of the theme inheritance implementation (sorry!) but I could not debug without it.)
- Create a `Theme` class. It contains all logic for looking colored icon versions up and is independent of both Nemo and Caja. Reading of `index.theme` is done using `ConfigParser`.
- Use the new `Theme` class in both extensions. For this, I also created a new base class for them, which should make it easier to keep both versions (Nemo and Caja) in sync.

I have also included support for home folders (as in @mtwebster 's pull request).
