### PR TITLE
caja extension: add dummy get_background_items function

### DIFF
--- a/caja-extensions/caja-folder-color-switcher.py
+++ b/caja-extensions/caja-folder-color-switcher.py
@@ -109,6 +109,9 @@ class ChangeColorFolder(GObject.GObject, Caja.MenuProvider):
             # Touch the directory to make Caja re-render its icons
             subprocess.call(["touch", path])
 
+    def get_background_items(self, window, current_folder):
+        return []
+
     # Caja invoke this function in its startup > Then, create menu entry
     def get_file_items(self, window, items_selected):
         # No items selected


### PR DESCRIPTION
same as in Nemo extension - silences runtime warnings about CAJA_IS_MENU_PROVIDER

similar fixes:
https://github.com/linuxmint/nemo-extensions/commit/89eda24fa955f3fce15bd48148a775700ee348da
https://github.com/linuxmint/nemo-extensions/commit/0e9012724cfca6b27a225eefae7f43596d2668df
https://github.com/mate-desktop/python-caja/commit/5815f585f8a6ae967aad703f39cc0dfbae669ff3