### PR TITLE
Fix PyGIDeprecationWarnings

### DIFF
--- a/nemo-extensions/nemo-folder-color-switcher.py
+++ b/nemo-extensions/nemo-folder-color-switcher.py
@@ -67,14 +67,14 @@ COLORS = collections.OrderedDict ([
 
 class Theme(object):
     KNOWN_DIRECTORIES = {
-        GLib.get_user_special_dir(GLib.USER_DIRECTORY_DESKTOP): 'user-desktop.svg',
-        GLib.get_user_special_dir(GLib.USER_DIRECTORY_DOCUMENTS): 'folder-documents.svg',
-        GLib.get_user_special_dir(GLib.USER_DIRECTORY_DOWNLOAD): 'folder-download.svg',
-        GLib.get_user_special_dir(GLib.USER_DIRECTORY_MUSIC): 'folder-music.svg',
-        GLib.get_user_special_dir(GLib.USER_DIRECTORY_PICTURES): 'folder-pictures.svg',
-        GLib.get_user_special_dir(GLib.USER_DIRECTORY_PUBLIC_SHARE): 'folder-publicshare.svg',
-        GLib.get_user_special_dir(GLib.USER_DIRECTORY_TEMPLATES): 'folder-templates.svg',
-        GLib.get_user_special_dir(GLib.USER_DIRECTORY_VIDEOS): 'folder-video.svg',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DESKTOP): 'user-desktop.svg',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOCUMENTS): 'folder-documents.svg',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOWNLOAD): 'folder-download.svg',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_MUSIC): 'folder-music.svg',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES): 'folder-pictures.svg',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PUBLIC_SHARE): 'folder-publicshare.svg',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_TEMPLATES): 'folder-templates.svg',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_VIDEOS): 'folder-video.svg',
         GLib.get_home_dir(): 'folder-home.svg',
     }
     logger.debug("Known directories are: %s" % KNOWN_DIRECTORIES)


### PR DESCRIPTION
Running `xdg-open .` from the terminal currently results in some deprecations warnings when the latest `pygobject` module is installed:

```
/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py:70: PyGIDeprecationWarning: GLib.USER_DIRECTORY_DESKTOP is deprecated; use GLib.UserDirectory.DIRECTORY_DESKTOP instead
  GLib.get_user_special_dir(GLib.USER_DIRECTORY_DESKTOP): 'user-desktop.svg',
/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py:71: PyGIDeprecationWarning: GLib.USER_DIRECTORY_DOCUMENTS is deprecated; use GLib.UserDirectory.DIRECTORY_DOCUMENTS instead
  GLib.get_user_special_dir(GLib.USER_DIRECTORY_DOCUMENTS): 'folder-documents.svg',
/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py:72: PyGIDeprecationWarning: GLib.USER_DIRECTORY_DOWNLOAD is deprecated; use GLib.UserDirectory.DIRECTORY_DOWNLOAD instead
  GLib.get_user_special_dir(GLib.USER_DIRECTORY_DOWNLOAD): 'folder-download.svg',
/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py:73: PyGIDeprecationWarning: GLib.USER_DIRECTORY_MUSIC is deprecated; use GLib.UserDirectory.DIRECTORY_MUSIC instead
  GLib.get_user_special_dir(GLib.USER_DIRECTORY_MUSIC): 'folder-music.svg',
/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py:74: PyGIDeprecationWarning: GLib.USER_DIRECTORY_PICTURES is deprecated; use GLib.UserDirectory.DIRECTORY_PICTURES instead
  GLib.get_user_special_dir(GLib.USER_DIRECTORY_PICTURES): 'folder-pictures.svg',
/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py:75: PyGIDeprecationWarning: GLib.USER_DIRECTORY_PUBLIC_SHARE is deprecated; use GLib.UserDirectory.DIRECTORY_PUBLIC_SHARE instead
  GLib.get_user_special_dir(GLib.USER_DIRECTORY_PUBLIC_SHARE): 'folder-publicshare.svg',
/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py:76: PyGIDeprecationWarning: GLib.USER_DIRECTORY_TEMPLATES is deprecated; use GLib.UserDirectory.DIRECTORY_TEMPLATES instead
  GLib.get_user_special_dir(GLib.USER_DIRECTORY_TEMPLATES): 'folder-templates.svg',
/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py:77: PyGIDeprecationWarning: GLib.USER_DIRECTORY_VIDEOS is deprecated; use GLib.UserDirectory.DIRECTORY_VIDEOS instead
  GLib.get_user_special_dir(GLib.USER_DIRECTORY_VIDEOS): 'folder-video.svg',
```

The given PR performs the changes proposed by the deprecation warnings.