### PR TITLE
Fixes for Mint 19.1 / Nemo 4 and Mint-Y

### DIFF
--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -17,8 +17,15 @@
 # along with Folder Color; if not, see http://www.gnu.org/licenses
 # for more information.
 
-import os, gettext, locale, configparser, collections, re
+import os, gettext, locale, collections, re
 import subprocess
+try:
+	# Python2 (Mint 19)
+	import ConfigParser as configparser
+except:
+	# Python 3 (Mint 19.1)
+	import configparser
+
 from gi.repository import Nemo, GObject, Gio, GLib, Gtk, Gdk, GdkPixbuf, cairo
 _ = gettext.gettext
 P_ = gettext.ngettext

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -17,7 +17,7 @@
 # along with Folder Color; if not, see http://www.gnu.org/licenses
 # for more information.
 
-import os, gettext, locale, urllib.parse, collections
+import os, gettext, locale, configparser, collections, re
 import subprocess
 from gi.repository import Nemo, GObject, Gio, GLib, Gtk, Gdk, GdkPixbuf, cairo
 _ = gettext.gettext
@@ -81,6 +81,28 @@ class Theme(object):
     }
     logger.debug("Known themes are: %s" % KNOWN_THEMES)
 
+    # view[zoom-level] -> icon size
+    # Notes:
+    # - icon size:    values from nemo/libnemo-private/nemo-icon-info.h (checked)
+    # - list view:    icon sizes don't match the defined sizes in nemo-icon-info.h (yet)
+    # - compact view: hasn't defined sizes defined in nemo-icon-info.h
+    ZOOM_LEVEL_ICON_SIZES = {
+        'icon-view'    : [24, 32, 48, 64, 96, 128, 256],
+        #'list-view'    : [16, 24, 32, 48, 72, 96,  192], # defined values
+        # sizes measured manually for reasons above
+        'list-view'    : [16, 16, 24, 32, 48, 72,  96 ],
+        'compact-view' : [16, 16, 18, 24, 36, 48,  96 ]
+    }
+    ZOOM_LEVELS = {
+        'smallest' : 0,
+        'smaller'  : 1,
+        'small'    : 2,
+        'standard' : 3,
+        'large'    : 4,
+        'larger'   : 5,
+        'largest'  : 6
+    }
+
     def __init__(self, base_name, color_variant):
         self.base_name = base_name
         self.color_variant = color_variant
@@ -88,10 +110,13 @@ class Theme(object):
         self.base_path = str("/usr/share/icons/%s/" % self)
 
         self.variants = {}
-        self.default_folder_file = None
+        self.default_folder_file = {}
         self.inherited_themes_cache = None
         self.supported_theme_colors = None
+        self.supported_icon_sizes = {}
+        self.icon_path_cache = {}
 
+        # https://standards.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html
         self.KNOWN_DIRECTORIES = {
             GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DESKTOP): 'user-desktop',
             GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOCUMENTS): 'folder-documents',
@@ -101,10 +126,10 @@ class Theme(object):
             GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PUBLIC_SHARE): 'folder-publicshare',
             GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_TEMPLATES): 'folder-templates',
             GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_VIDEOS): 'folder-videos',
-            GLib.get_home_dir(): 'folder-home',
+            GLib.get_home_dir(): 'user-home'
         }
 
-        self.discover_image_support()
+        self.discover_supported_icon_sizes()
 
     def __str__(self):
         if self.color_variant:
@@ -136,39 +161,153 @@ class Theme(object):
         if key in self.variants.keys():
             return self.variants[key]
         else:
-            variant = Theme(base_name, color)
-            self.variants[key] = variant
-            return variant
+            try:
+                variant = Theme(base_name, color)
+                self.variants[key] = variant
+                return variant
+            except:
+                # Theme does not exist
+                return None
 
-    def discover_image_support(self):
+    def discover_image_support(self, icon_size):
         logger.debug("Discovering image support for theme %s" % self)
 
+        if icon_size in self.icon_path_cache:
+            logger.info("Icons paths for theme %s in size %i are cached" % (self, icon_size))
+            return
+
+        self.default_folder_file[icon_size] = None
+        self.icon_path_cache[icon_size] = {}
+
+        # special directories
         for key in self.KNOWN_DIRECTORIES.keys():
-            found = False
+            self.icon_path_cache[icon_size][key] = None
 
             for ext in (".png", ".svg"):
-                path = os.path.join(self.base_path, "places", "48", self.KNOWN_DIRECTORIES[key] + ext)
+                path = os.path.join(self.base_path, "places", str(icon_size), self.KNOWN_DIRECTORIES[key] + ext)
 
                 if os.path.isfile(path):
                     logger.debug("Found icon for '%s' at '%s'" % (key, path))
-                    self.KNOWN_DIRECTORIES[key] = path
-                    found = True
+                    self.icon_path_cache[icon_size][key] = path
                     break
 
-            if not found:
-                self.KNOWN_DIRECTORIES[key] = None
-
+        # usual directories
         for ext in (".png", ".svg"):
-            path = os.path.join(self.base_path, "places", "48", "folder" + ext)
+            path = os.path.join(self.base_path, "places", str(icon_size), "folder" + ext)
 
             if os.path.isfile(path):
-                logger.debug("Found generic folder icon at '%s'" % (path,))
-
-                self.default_folder_file = path
+                logger.debug("Found generic folder icon at '%s'" % path)
+                self.default_folder_file[icon_size] = path
                 break
 
+    def discover_supported_icon_sizes(self):
+        parser = configparser.ConfigParser()
+        index_theme_path = self.get_index_theme_path()
+
+        if not os.path.isfile(index_theme_path):
+            logger.debug("Theme %s is not available" % self)
+            raise Exception("Theme %s is not available" % self)
+
+        try:
+            logger.debug('Trying to read index.theme at %s' % index_theme_path)
+            parser.read(index_theme_path)
+
+            for section in parser.sections():
+                search = re.search("^places/(\\d+)$",section)
+
+                if search:
+                    scalable = parser.get(section, "Type")
+                    logger.debug("Discovered theme icon size: %s, type: %s", search.group(1), scalable )
+                    self.supported_icon_sizes[int(search.group(1))] = scalable
+
+        except:
+            logger.info('Could not read index.theme for theme %s' % self)
+
+    def get_default_view_icon_size(self):
+        default_view = self.get_default_view()
+        zoom_lvl_index = self.get_default_view_zoom_level(default_view)
+
+        return self.ZOOM_LEVEL_ICON_SIZES[default_view][zoom_lvl_index]
+
+    def get_current_view_icon_size(self):
+        # get the folder where we are currently in
+        dir = ChangeColorFolder.current_directory
+        info = dir.query_info('metadata::*', 0, None)
+        meta_view = info.get_attribute_string('metadata::nemo-default-view')
+
+        if meta_view:
+            match = re.search("OAFIID:Nemo_File_Manager_(\\w+)_View", meta_view)
+            view = match.group(1).lower() + "-view"
+        else:
+            view = self.get_default_view()
+
+        if view in self.ZOOM_LEVEL_ICON_SIZES.keys():
+            # the zoom level is store as string ('0', ... , '6')
+            meta_zoom_lvl = info.get_attribute_string("metadata::nemo-%s-zoom-level" % view)
+
+            if not meta_zoom_lvl:
+                # if view is set while the conresponding zoom level is not
+                # (e.g. user switched views in this folder but never used zoom)
+                zoom_level = self.get_default_view_zoom_level(view)
+            else:
+                zoom_level = int(meta_zoom_lvl)
+
+            icon_size = self.ZOOM_LEVEL_ICON_SIZES[view][zoom_level]
+            logger.debug("Icon size for the current view is: %i" % icon_size)
+            return icon_size
+
+        logger.debug("falling back to defaults")
+        return self.get_default_view_icon_size()
+
+    def get_best_available_icon_size(self, desired_icon_size):
+        logger.debug("Finding the best available icon size for size: %i", desired_icon_size)
+
+        # prefer SVG (scalable size) if available
+        for size in self.supported_icon_sizes:
+            if self.supported_icon_sizes[size] == "Scalable":
+                logger.debug("Best available icon size is: %i (scalable)", size)
+                return size
+
+        # direct match
+        if self.supported_icon_sizes.get(desired_icon_size):
+            logger.debug("Desired icon size is avaiable: %i", desired_icon_size)
+            return desired_icon_size
+
+        # choose closest matching icon size
+        best_abs = 9999
+        for val in self.supported_icon_sizes:
+            vabs = abs(val - desired_icon_size)
+
+            if vabs < best_abs:
+                best_abs = vabs
+                best_size = val
+
+        logger.debug("Best available icon size is: %i", best_size)
+        return best_size
+
+    def get_default_view(self):
+        nemo_prefs = Gio.Settings.new("org.nemo.preferences")
+        return nemo_prefs.get_string("default-folder-viewer")
+
+    def get_default_view_zoom_level(self, view="icon-view"):
+        zoom_lvl_string = Gio.Settings.new("org.nemo." + view).get_string("default-zoom-level")
+        return self.ZOOM_LEVELS[zoom_lvl_string]
+
     def get_folder_icon_path(self, directory=None):
-        return self.KNOWN_DIRECTORIES.get(directory, self.default_folder_file)
+        if ChangeColorFolder.ignore_view_metadata:
+            logger.info("Nemo is set to ignore view metadata")
+            desired_size = self.get_default_view_icon_size()
+        else:
+            logger.info("Nemo is set to apply view metadata")
+            desired_size = self.get_current_view_icon_size()
+
+        icon_size = self.get_best_available_icon_size(desired_size)
+
+        # scan for available folder icons
+        self.discover_image_support(icon_size)
+
+        # return the icon path if available or fall back to the generic folder icon
+        return self.icon_path_cache[icon_size].get(directory.get_path(), self.default_folder_file[icon_size])
 
     def get_index_theme_path(self):
         return os.path.join(self.base_path, "index.theme")
@@ -180,9 +319,7 @@ class Theme(object):
         if self.inherited_themes_cache == None:
             result = []
 
-            logger.debug('Importing config parser...')
-            import ConfigParser
-            parser = ConfigParser.RawConfigParser()
+            parser = configparser.RawConfigParser()
             index_theme_path = self.get_index_theme_path()
             try:
                 logger.debug('Trying to read index.theme at %s' % index_theme_path)
@@ -220,7 +357,7 @@ class Theme(object):
             return self.get_variant(self.base_name, color)
 
     def find_folder_icon(self, color, directory=None):
-        logger.debug("Trying to find icon for directory %s in %s for theme %s" % (directory, color, self))
+        logger.debug("Trying to find icon for directory %s in %s for theme %s" % (directory.get_path(), color, self))
         relevant_ancestor = self.get_ancestor_defining_folder_svg(directory)
         if not relevant_ancestor:
             logger.debug("Could not find ancestor defining SVG")
@@ -229,15 +366,19 @@ class Theme(object):
         logger.debug("Ancestor defining SVG is %s" % relevant_ancestor)
         colored_theme = relevant_ancestor.sibling(color)
 
+        if not colored_theme:
+            return None
+
         return colored_theme.get_folder_icon_path(directory)
 
-    def get_supported_colors(self, paths):
+    def get_supported_colors(self, directories):
         if self.supported_theme_colors == None:
             supported_colors = []
 
             for color in COLORS:
+                logger.debug("Checking for theme color %s" % color)
                 color_supported = True
-                for directory in paths:
+                for directory in directories:
                     icon_path = self.find_folder_icon(color, directory)
                     if not icon_path:
                         color_supported = False
@@ -258,6 +399,9 @@ class Theme(object):
 
 
 class ChangeFolderColorBase(object):
+    current_directory = None
+    ignore_view_metadata = False
+
     def update_theme(self, theme_str):
         logger.info("Current icon theme: %s", theme_str)
         self.theme = Theme.from_theme_name(theme_str)
@@ -269,14 +413,14 @@ class ChangeFolderColorBase(object):
             if item.is_gone():
                 continue
 
-            # Get object
-            path = urllib.parse.unquote(item.get_uri()[7:])
+            # get Gio.File object
             directory = item.get_location()
+            path = directory.get_path()
             info = directory.query_info('metadata::custom-icon', 0, None)
 
             # Set color
             if color:
-                icon_path = self.theme.find_folder_icon(color, path)
+                icon_path = self.theme.find_folder_icon(color, directory)
                 if icon_path:
                     icon_file = Gio.File.new_for_path(icon_path)
                     icon_uri = icon_file.get_uri()
@@ -324,7 +468,7 @@ css_colors = b"""
 
 provider = Gtk.CssProvider()
 provider.load_from_data(css_colors)
-screen = Gdk.Screen.get_default();
+screen = Gdk.Screen.get_default()
 Gtk.StyleContext.add_provider_for_screen (screen, provider, 600) # GTK_STYLE_PROVIDER_PRIORITY_APPLICATION
 
 class ChangeColorFolder(ChangeFolderColorBase, GObject.GObject, Nemo.MenuProvider, Nemo.NameAndDescProvider):
@@ -339,13 +483,22 @@ class ChangeColorFolder(ChangeFolderColorBase, GObject.GObject, Nemo.MenuProvide
         self.settings.connect("changed::icon-theme", self.on_theme_changed)
         self.on_theme_changed(None, None)
 
+        self.nemo_settings = Gio.Settings.new("org.nemo.preferences")
+        self.nemo_settings.connect("changed::ignore-view-metadata", self.on_ignore_view_metadata_changed)
+        self.on_ignore_view_metadata_changed(None)
+
     def on_theme_changed(self, settings, key):
         self.update_theme(self.settings.get_string("icon-theme"))
+
+    def on_ignore_view_metadata_changed(self, settings, key="ignore-view-metadata"):
+        ChangeColorFolder.ignore_view_metadata = self.nemo_settings.get_boolean(key)
 
     def menu_activate_cb(self, menu, color, folders):
         self.set_folder_icons(color, folders)
 
     def get_background_items(self, window, current_folder):
+        logger.debug("Current folder is: " + current_folder.get_name())
+        ChangeColorFolder.current_directory = current_folder.get_location()
         return
 
     def get_name_and_desc(self):
@@ -357,26 +510,23 @@ class ChangeColorFolder(ChangeFolderColorBase, GObject.GObject, Nemo.MenuProvide
             # No items selected
             return
 
-        paths = []
+        directories = []
         for item in items_selected:
             # Only folders
             if not item.is_directory():
                 logger.info("A selected item is not a directory, exiting")
                 return
 
-            item_uri = item.get_uri()
-            logger.debug('URI "%s" is in selection', item_uri)
-            uri_tuple = urllib.parse.urlparse(item_uri)
-            # GNOME can only handle "file" URI scheme
-            # break if the file URI has weired components (such as params)
-            if uri_tuple[0] != 'file' or uri_tuple[1] or uri_tuple[3] or uri_tuple[4] or uri_tuple[5]:
-                logger.info("A selected item as a weired URI, exiting")
-                return
-            path = uri_tuple[2]
-            logger.debug('Valid path selected: "%s"', path)
-            paths.append(path)
+            logger.debug('URI "%s" is in selection', item.get_uri())
 
-        supported_colors = self.theme.get_supported_colors(paths)
+            if item.get_uri_scheme() != 'file':
+                return
+
+            directory = item.get_location()
+            logger.debug('Valid path selected: "%s"', directory.get_path())
+            directories.append(directory)
+
+        supported_colors = self.theme.get_supported_colors(directories)
 
         if supported_colors:
             logger.debug("At least one color supported: creating menu entry")

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -238,8 +238,8 @@ class Theme(object):
 
     def get_current_view_icon_size(self):
         # get the folder where we are currently in
-        dir = ChangeColorFolder.current_directory
-        info = dir.query_info('metadata::*', 0, None)
+        current_dir = ChangeColorFolder.current_directory
+        info = current_dir.query_info('metadata::*', 0, None)
         meta_view = info.get_attribute_string('metadata::nemo-default-view')
 
         if meta_view:

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -26,7 +26,7 @@ except:
 	# Python 3 (Mint 19.1)
 	import configparser
 
-from gi.repository import Nemo, GObject, Gio, GLib, Gtk, Gdk, GdkPixbuf, cairo
+from gi.repository import Nemo, GObject, Gio, GLib, Gtk, Gdk
 _ = gettext.gettext
 P_ = gettext.ngettext
 


### PR DESCRIPTION
The plugin needed changes for Mint 19.1 and Mint-Y because of the following facts:
- since Mint 19.1 (Nemo 4) the default zoom level for the icon view changed causing icons to grow from 48px to 64px
- Mint-Y provides only (unscalable) PNG icons
- Nemo 4 seems to use Python3 for plugins

The first two facts caused that icons set with this plugin are unsharp *by default* as it set icons with 48px (hardcoded).

I did the changes so that the plugin now:
- first scans for all available icon sizes (by parsing the index.theme file) 
- finds all (specialized) folder icons and stores their path (cache)
- selects the best icon size (SVG > direct match > closest match) based on the users Nemo preferences ("ignore per-folder view preferences", default view, default zoom levels) and if necessary on a per-folder basis by querying GVFS metadata
- works with python3 (-> configparser)
- made hacky use of urllib obsolete (using Gio for that now)