### PR TITLE
Skip files in selection instead of stopping

### DIFF
--- a/usr/share/caja-python/extensions/caja-folder-color-switcher.py
+++ b/usr/share/caja-python/extensions/caja-folder-color-switcher.py
@@ -291,10 +291,6 @@ class ChangeFolderColorBase(object):
 class ChangeColorFolder(ChangeFolderColorBase, GObject.GObject, Caja.MenuProvider):
     def __init__(self):
         logger.info("Initializing folder-color-switcher extension...")
-        locale.setlocale(locale.LC_ALL, '')
-        gettext.bindtextdomain('folder-color-switcher')
-        gettext.textdomain('folder-color-switcher')
-
         self.SEPARATOR = u'\u2015' * 4
         self.settings = Gio.Settings.new("org.mate.interface")
         self.settings.connect("changed::icon-theme", self.on_theme_changed)
@@ -314,6 +310,10 @@ class ChangeColorFolder(ChangeFolderColorBase, GObject.GObject, Caja.MenuProvide
         if not items_selected:
             # No items selected
             return
+
+        locale.setlocale(locale.LC_ALL, '')
+        gettext.bindtextdomain('folder-color-switcher')
+        gettext.textdomain('folder-color-switcher')
 
         directories = []
         directories_selected = []

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -529,11 +529,13 @@ class ChangeColorFolder(ChangeFolderColorBase, GObject.GObject, Nemo.MenuProvide
             return
 
         directories = []
+        directories_selected = []
+
         for item in items_selected:
             # Only folders
             if not item.is_directory():
-                logger.info("A selected item is not a directory, exiting")
-                return
+                logger.info("A selected item is not a directory, skipping")
+                continue
 
             logger.debug('URI "%s" is in selection', item.get_uri())
 
@@ -543,14 +545,18 @@ class ChangeColorFolder(ChangeFolderColorBase, GObject.GObject, Nemo.MenuProvide
             directory = item.get_location()
             logger.debug('Valid path selected: "%s"', directory.get_path())
             directories.append(directory)
+            directories_selected.append(item)
+
+        if not directories_selected:
+            return
 
         supported_colors = self.theme.get_supported_colors(directories)
 
         if supported_colors:
             logger.debug("At least one color supported: creating menu entry")
             item = Nemo.MenuItem(name='ChangeFolderColorMenu::Top')
-            item.set_widget_a(self.generate_widget(supported_colors, items_selected))
-            item.set_widget_b(self.generate_widget(supported_colors, items_selected))
+            item.set_widget_a(self.generate_widget(supported_colors, directories_selected))
+            item.set_widget_b(self.generate_widget(supported_colors, directories_selected))
             return Nemo.MenuItem.new_separator('ChangeFolderColorMenu::TopSep'),   \
                    item,                                                           \
                    Nemo.MenuItem.new_separator('ChangeFolderColorMenu::BotSep')


### PR DESCRIPTION
multiple folders can be colored at once, but only if no files are within the same selection. If files are in the section, the menu isn't shown.

this PR fixes this: files in the selection will be skipped and the remaining folders will be colored.

Also removes some diffs between nemo and caja version (removes dependency on urlparse).