### PR TITLE
Major rewrite: Use Gtk.IconTheme to find icons (fixes #22)

### DIFF
--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -352,8 +352,6 @@ class ChangeFolderColor(ChangeFolderColorBase, GObject.GObject, Nemo.MenuProvide
         gettext.bindtextdomain('folder-color-switcher')
         gettext.textdomain('folder-color-switcher')
 
-        self.SEPARATOR = u'\u2015' * 4
-
     def menu_activate_cb(self, menu, color, folders):
         self.set_folder_colors(folders, color)
 

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -17,7 +17,7 @@
 # along with Folder Color; if not, see http://www.gnu.org/licenses
 # for more information.
 
-import os, gettext, locale, collections, re, subprocess, gi
+import os, gettext, locale, collections, re, gi
 
 gi.require_version('Gtk', '3.0')
 gi.require_version('Nemo', '3.0')
@@ -307,8 +307,8 @@ class ChangeFolderColorBase(object):
                 # A color of None unsets the custom-icon
                 directory.set_attribute('metadata::custom-icon', Gio.FileAttributeType.INVALID, 0, 0, None)
 
-            # Touch the directory to make Nemo/Caja re-render its icons
-            subprocess.call(["touch", path])
+            # update the directory's modified date to make Nemo/Caja re-render its icon
+            os.utime(path, None)
 
 
 css_colors = b"""

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -73,11 +73,14 @@ COLORS = collections.OrderedDict ([
             ('Black', _('Black'))
            ])
 
-class Theme(object):
-    KNOWN_THEMES = {
-        'Mint-X': 'Green',
-        'Mint-Y': 'Green',
+
+class ColoredIconThemeSet:
+    # ordered because matched using "startsWith"
+    KNOWN_THEMES = collections.OrderedDict({
         'Mint-X-Dark': 'Green',
+        'Mint-X': 'Green',
+        'Mint-Y-Dark': 'Green', # falls back to Mint-Y itself, but has color variants
+        'Mint-Y': 'Green',
         'Rave-X-CX': 'Beige',
         'Faience': 'Beige',
         'gnome': 'Beige',
@@ -85,9 +88,88 @@ class Theme(object):
         'menta': 'Green',
         'mate': 'Beige',
         'oxygen': 'Blue'
-    }
+    })
     logger.debug("Known themes are: %s" % KNOWN_THEMES)
 
+    def __init__(self):
+        self.availableColoredIconThemes = {}
+
+        self.it_settings = Gio.Settings.new("org.cinnamon.desktop.interface")
+        self._on_icon_theme_changed(None)
+        self.currentIconTheme.connect('changed', self._on_icon_theme_changed)
+
+    def _on_icon_theme_changed(self, theme):
+        # get current icon theme, might be a variant, e.g. "Mint-Y-Aqua"
+        self.currentIconTheme = Gtk.IconTheme.get_default()
+
+        # get its name
+        self.currentIconThemeName = self.it_settings.get_string("icon-theme")
+        logger.debug("IconTheme changed to: %s", self.currentIconThemeName)
+
+        self._determine_base_icon_theme()
+        self._load_available_colors()
+
+    def _determine_base_icon_theme(self):
+        # the determined base icon theme, e.g. "Mint-Y"
+        self.currentBaseIconThemeName = None
+
+        # exact match (== no color variant in use)
+        if self.currentIconThemeName in self.KNOWN_THEMES:
+            self.currentBaseIconThemeName = self.currentIconThemeName
+            return
+
+        # naive via name
+        for theme in self.KNOWN_THEMES:
+            if self.currentIconThemeName.startswith(theme):
+                self.currentBaseIconThemeName = theme
+                break
+
+    def _load_available_colors(self):
+        if self.currentBaseIconThemeName is None:
+            # non-supported icon theme
+            self.availableColoredIconThemes = {}
+            return
+
+        # add base theme color, when using a variant
+        if self.currentBaseIconThemeName != self.currentIconThemeName:
+            it = Gtk.IconTheme.new()
+            it.set_custom_theme(self.currentBaseIconThemeName)
+            base_color = self.KNOWN_THEMES[self.currentBaseIconThemeName]
+            self.availableColoredIconThemes[base_color] = it
+
+        for color in COLORS:
+            it = Gtk.IconTheme.new()
+            it.set_custom_theme(
+            	'%s-%s' % (self.currentBaseIconThemeName, color))
+
+            # check if the default 'folder' icon is available for the given color (size: 32).
+            # HACK: to ignore fallback icons, check that the base theme name is included in the icon path
+            icon_info = it.choose_icon(['folder', None], 32, 0)
+
+            if not icon_info or self.currentBaseIconThemeName not in icon_info.get_filename():
+                continue
+
+            self.availableColoredIconThemes[color] = it
+
+    def get_available_colors(self):
+        return self.availableColoredIconThemes.keys()
+
+    def get_icon_uri_for_color_size_and_scale(self, icon_name: str, color: str, size: int, scale: int) -> str:
+        logger.debug('Searching: icon "%s" for color "%s", size %i and scale %i', icon_name, color, size, scale)
+        icon_theme = self.availableColoredIconThemes.get(color, None)
+
+        if icon_theme:
+            icon_info = icon_theme.choose_icon_for_scale([icon_name, None], size, scale, 0)
+            if icon_info:
+                uri = GLib.filename_to_uri(icon_info.get_filename(), None)
+                logger.debug("Found icon at URI: %s", uri)
+                return uri
+
+        logger.warning('No icon "%s" found for color "%s", size %i and scale %i', icon_name, color, size, scale)
+        return None
+
+
+class ChangeFolderColorBase(object):
     # view[zoom-level] -> icon size
     # Notes:
     # - icon size:    values from nemo/libnemo-private/nemo-icon-info.h (checked)
@@ -100,6 +182,7 @@ class Theme(object):
         'list-view'    : [16, 16, 24, 32, 48, 72,  96 ],
         'compact-view' : [16, 16, 18, 24, 36, 48,  96 ]
     }
+
     ZOOM_LEVELS = {
         'smallest' : 0,
         'smaller'  : 1,
@@ -110,148 +193,71 @@ class Theme(object):
         'largest'  : 6
     }
 
-    def __init__(self, base_name, color_variant):
-        self.base_name = base_name
-        self.color_variant = color_variant
+    # https://standards.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html
+    KNOWN_DIRECTORIES = {
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DESKTOP): 'user-desktop',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOCUMENTS): 'folder-documents',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOWNLOAD): 'folder-download',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_MUSIC): 'folder-music',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES): 'folder-pictures',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PUBLIC_SHARE): 'folder-publicshare',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_TEMPLATES): 'folder-templates',
+        GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_VIDEOS): 'folder-videos',
+        GLib.get_home_dir(): 'user-home'
+    }
 
-        self.base_path = str("/usr/share/icons/%s/" % self)
+    def __init__(self):
+        self.current_directory = None
 
-        self.variants = {}
-        self.default_folder_file = {}
-        self.inherited_themes_cache = None
-        self.supported_theme_colors = None
-        self.supported_icon_sizes = {}
-        self.icon_path_cache = {}
+        # view preferences
+        self.ignore_view_metadata = False
+        self.default_view = None
 
-        # https://standards.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html
-        self.KNOWN_DIRECTORIES = {
-            GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DESKTOP): 'user-desktop',
-            GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOCUMENTS): 'folder-documents',
-            GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOWNLOAD): 'folder-download',
-            GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_MUSIC): 'folder-music',
-            GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES): 'folder-pictures',
-            GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PUBLIC_SHARE): 'folder-publicshare',
-            GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_TEMPLATES): 'folder-templates',
-            GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_VIDEOS): 'folder-videos',
-            GLib.get_home_dir(): 'user-home'
-        }
+        self.themeset = ColoredIconThemeSet()
 
-        self.discover_supported_icon_sizes()
+        self.nemo_settings = Gio.Settings.new("org.nemo.preferences")
+        self.nemo_settings.connect("changed::ignore-view-metadata", self.on_ignore_view_metadata_changed)
+        self.nemo_settings.connect("changed::default-folder-viewer", self.on_default_view_changed)
+        self.on_ignore_view_metadata_changed(None)
+        self.on_default_view_changed(None)
 
-    def __str__(self):
-        if self.color_variant:
-            return "%s-%s" % (self.base_name, self.color_variant)
-        else:
-            return "%s" % self.base_name
+    def on_ignore_view_metadata_changed(self, settings, key="ignore-view-metadata"):
+        self.ignore_view_metadata = self.nemo_settings.get_boolean(key)
 
-    @staticmethod
-    def parse(theme_str):
-        base_name = theme_str
-        color_variant = None
-        for color in COLORS:
-            if theme_str.endswith("-%s" % color):
-                base_name = theme_str[:-len("-%s" % color)]
-                color_variant = color
-        return base_name, color_variant
+    def on_default_view_changed(self, settings, key="default-folder-viewer"):
+        self.default_view = self.nemo_settings.get_string(key)
 
-    @staticmethod
-    def from_theme_name(theme_str):
-        base_name, color_variant = Theme.parse(theme_str)
-        return Theme(base_name, color_variant)
-
-    def get_variant(self, base_name, color):
-        if color is not None:
-            key = "%s-%s" % (base_name, color)
-        else:
-            key = "%s" % base_name
-
-        if key in self.variants.keys():
-            return self.variants[key]
-        else:
-            try:
-                variant = Theme(base_name, color)
-                self.variants[key] = variant
-                return variant
-            except:
-                # Theme does not exist
-                return None
-
-    def discover_image_support(self, icon_size):
-        logger.debug("Discovering image support for theme %s" % self)
-
-        if icon_size in self.icon_path_cache:
-            logger.info("Icons paths for theme %s in size %i are cached" % (self, icon_size))
-            return
-
-        self.default_folder_file[icon_size] = None
-        self.icon_path_cache[icon_size] = {}
-
-        # special directories
-        for key in self.KNOWN_DIRECTORIES.keys():
-            self.icon_path_cache[icon_size][key] = None
-
-            for ext in (".png", ".svg"):
-                path = os.path.join(self.base_path, self.supported_icon_sizes[icon_size][1], self.KNOWN_DIRECTORIES[key] + ext)
-
-                if os.path.isfile(path):
-                    logger.debug("Found icon for '%s' at '%s'" % (key, path))
-                    self.icon_path_cache[icon_size][key] = path
-                    break
-
-        # usual directories
-        for ext in (".png", ".svg"):
-            path = os.path.join(self.base_path, self.supported_icon_sizes[icon_size][1], "folder" + ext)
-
-            if os.path.isfile(path):
-                logger.debug("Found generic folder icon at '%s'" % path)
-                self.default_folder_file[icon_size] = path
-                break
-
-    def discover_supported_icon_sizes(self):
-        parser = configparser.ConfigParser()
-        index_theme_path = self.get_index_theme_path()
-
-        if not os.path.isfile(index_theme_path):
-            logger.debug("Theme %s is not available" % self)
-            raise Exception("Theme %s is not available" % self)
-
-        try:
-            logger.debug('Trying to read index.theme at %s' % index_theme_path)
-            parser.read(index_theme_path)
-
-            for section in parser.sections():
-                search = re.search("^places/(\\d+)(@2x)*$",section)
-
-                if search:
-                    icon_type = parser.get(section, "Type")
-                    try:
-                        icon_scale = parser.get(section, "Scale")
-                    except:
-                        icon_scale = 1
-
-                    icon_size = int(search.group(1)) * int(icon_scale)
-                    logger.debug("Discovered theme icon size: %s, type: %s, scale: %s, section: %s", icon_size, icon_type, icon_scale, section)
-                    self.supported_icon_sizes[icon_size] = [icon_type, section]
-
-        except:
-            logger.info('Could not read index.theme for theme %s' % self)
+    def get_default_view_zoom_level(self, view="icon-view"):
+        zoom_lvl_string = Gio.Settings.new("org.nemo.%s" % view).get_string("default-zoom-level")
+        return ChangeFolderColorBase.ZOOM_LEVELS[zoom_lvl_string]
 
     def get_default_view_icon_size(self):
-        default_view = ChangeFolderColorBase.default_view
-        zoom_lvl_index = self.get_default_view_zoom_level(default_view)
-        return self.ZOOM_LEVEL_ICON_SIZES[default_view][zoom_lvl_index]
+        zoom_lvl_index = self.get_default_view_zoom_level(self.default_view)
+        return ChangeFolderColorBase.ZOOM_LEVEL_ICON_SIZES[self.default_view][zoom_lvl_index]
+
+    def get_folder_icon_name(self, directory):
+        logger.debug("get_folder_icon_name: %s", directory)
+        return ChangeFolderColorBase.KNOWN_DIRECTORIES.get(directory, 'folder')
+
+    def get_desired_icon_size(self):
+        if self.ignore_view_metadata:
+            logger.info("Nemo is set to ignore view metadata")
+            return self.get_default_view_icon_size()
+
+        logger.info("Nemo is set to apply view metadata")
+        return self.get_current_view_icon_size()
+
 
     def get_current_view_icon_size(self):
         # get the folder where we are currently in
-        current_dir = ChangeColorFolder.current_directory
-        info = current_dir.query_info('metadata::*', 0, None)
+        info = self.current_directory.query_info('metadata::*', 0, None)
         meta_view = info.get_attribute_string('metadata::nemo-default-view')
 
         if meta_view:
             match = re.search("OAFIID:Nemo_File_Manager_(\\w+)_View", meta_view)
             view = match.group(1).lower() + "-view"
         else:
-            view = ChangeFolderColorBase.default_view
+            view = self.default_view
 
         if view in self.ZOOM_LEVEL_ICON_SIZES.keys():
             # the zoom level is store as string ('0', ... , '6')
@@ -271,176 +277,33 @@ class Theme(object):
         logger.debug("falling back to defaults")
         return self.get_default_view_icon_size()
 
-    def get_best_available_icon_size(self, desired_icon_size):
-        logger.debug("Finding the best available icon size for size: %i", desired_icon_size)
 
-        logger.debug("[get_best_available_icon_size] supported: %s",
-            self.supported_icon_sizes)
+    def set_folder_colors(self, folders, color):
+        if color:
+            icon_size = self.get_desired_icon_size()
+            default_folder_icon_uri = self.themeset.get_icon_uri_for_color_size_and_scale('folder', color, icon_size, 1)
 
-        # prefer SVG (scalable size) if available
-        for size in self.supported_icon_sizes:
-            if self.supported_icon_sizes[size][0] == "Scalable":
-                logger.debug("Best available icon size is: %i (scalable)", size)
-                return size
+            if not default_folder_icon_uri:
+                return
 
-        # direct match
-        if self.supported_icon_sizes.get(desired_icon_size):
-            logger.debug("Desired icon size is avaiable: %i", desired_icon_size)
-            return desired_icon_size
-
-        # choose closest matching icon size
-        best_size = 128 # Just as a fallback
-        best_abs = 9999
-        for val in self.supported_icon_sizes:
-            vabs = abs(val - desired_icon_size)
-
-            if vabs < best_abs:
-                best_abs = vabs
-                best_size = val
-
-        logger.debug("Best available icon size is: %i", best_size)
-        return best_size
-
-    def get_default_view_zoom_level(self, view="icon-view"):
-        zoom_lvl_string = Gio.Settings.new("org.nemo." + view).get_string("default-zoom-level")
-        return self.ZOOM_LEVELS[zoom_lvl_string]
-
-    def get_folder_icon_path(self, directory=None):
-        if ChangeColorFolder.ignore_view_metadata:
-            logger.info("Nemo is set to ignore view metadata")
-            desired_size = self.get_default_view_icon_size()
-        else:
-            logger.info("Nemo is set to apply view metadata")
-            desired_size = self.get_current_view_icon_size()
-
-        icon_size = self.get_best_available_icon_size(desired_size)
-
-        # scan for available folder icons
-        self.discover_image_support(icon_size)
-
-        # return the icon path if available or fall back to the generic folder icon
-        return self.icon_path_cache[icon_size].get(directory.get_path(), self.default_folder_file[icon_size])
-
-    def get_index_theme_path(self):
-        return os.path.join(self.base_path, "index.theme")
-
-    def has_icon_for_folder(self, directory=None):
-        return self.get_folder_icon_path(directory) is not None
-
-    def inherited_themes(self):
-        if self.inherited_themes_cache == None:
-            result = []
-
-            parser = configparser.RawConfigParser()
-            index_theme_path = self.get_index_theme_path()
-            try:
-                logger.debug('Trying to read index.theme at %s' % index_theme_path)
-                parser.read(index_theme_path)
-                inherits_str = parser.get('Icon Theme', 'Inherits')
-                logger.debug('Theme %s inherits %s' % (self, inherits_str))
-
-                for parent in inherits_str.split(","):
-                    result.append(Theme.from_theme_name(parent))
-            except:
-                logger.info('Could not read index.theme for theme %s' % self)
-                result = []
-
-            self.inherited_themes_cache = result
-        return self.inherited_themes_cache
-
-    def get_ancestor_defining_folder_svg(self, directory=None):
-        if self.has_icon_for_folder(directory):
-            return self
-        for theme in self.inherited_themes():
-            ancestor = theme.get_ancestor_defining_folder_svg(directory)
-            if ancestor:
-                return ancestor
-        return None
-
-    def sibling(self, color):
-        if color == self.color:
-            # This theme implements the desired color
-            return self
-        elif color == Theme.KNOWN_THEMES.get(self.base_name):
-            # The base version of this theme implements the desired color
-            return self.get_variant(self.base_name, None)
-        else:
-            # The color belongs to a color variant
-            return self.get_variant(self.base_name, color)
-
-    def find_folder_icon(self, color, directory=None):
-        logger.debug("Trying to find icon for directory %s in %s for theme %s" % (directory.get_path(), color, self))
-        relevant_ancestor = self.get_ancestor_defining_folder_svg(directory)
-        if not relevant_ancestor:
-            logger.debug("Could not find ancestor defining SVG")
-            return None
-
-        logger.debug("Ancestor defining SVG is %s" % relevant_ancestor)
-        colored_theme = relevant_ancestor.sibling(color)
-
-        if not colored_theme:
-            return None
-
-        return colored_theme.get_folder_icon_path(directory)
-
-    def get_supported_colors(self, directories):
-        if self.supported_theme_colors == None:
-            supported_colors = []
-
-            for color in COLORS:
-                logger.debug("Checking for theme color %s" % color)
-                color_supported = True
-                for directory in directories:
-                    icon_path = self.find_folder_icon(color, directory)
-                    if not icon_path:
-                        color_supported = False
-                        break
-                if color_supported:
-                    supported_colors.append(color)
-
-            self.supported_theme_colors = supported_colors
-
-        return self.supported_theme_colors
-
-    @property
-    def color(self):
-        if self.color_variant:
-            return self.color_variant
-        else:
-            return Theme.KNOWN_THEMES.get(self.base_name)
-
-
-class ChangeFolderColorBase(object):
-    current_directory = None
-    ignore_view_metadata = False
-    default_view = None
-
-    def update_theme(self, theme_str):
-        logger.info("Current icon theme: %s", theme_str)
-        self.theme = Theme.from_theme_name(theme_str)
-        logger.info("Its color is %s", self.theme.color)
-
-    def set_folder_icons(self, color, items):
-        for item in items:
-
-            if item.is_gone():
+        for folder in folders:
+            if folder.is_gone():
                 continue
 
             # get Gio.File object
-            directory = item.get_location()
+            directory = folder.get_location()
             path = directory.get_path()
             info = directory.query_info('metadata::custom-icon', 0, None)
 
-            # Set color
             if color:
-                icon_path = self.theme.find_folder_icon(color, directory)
-                if icon_path:
-                    icon_file = Gio.File.new_for_path(icon_path)
-                    icon_uri = icon_file.get_uri()
+                icon_uri = default_folder_icon_uri
+                icon_name = self.get_folder_icon_name(path)
+
+                if icon_name != 'folder':
+                    icon_uri = self.themeset.get_icon_uri_for_color_size_and_scale(icon_name, color, icon_size, 1)
+
+                if icon_uri:
                     info.set_attribute_string('metadata::custom-icon', icon_uri)
-                    logger.info('Set custom-icon of %s to %s' % (path, icon_path))
-                else:
-                    logger.error('Could not find %s colored icon' % color)
             else:
                 # A color of None unsets the custom-icon
                 info.set_attribute('metadata::custom-icon', Gio.FileAttributeType.INVALID, 0)
@@ -484,39 +347,23 @@ provider.load_from_data(css_colors)
 screen = Gdk.Screen.get_default()
 Gtk.StyleContext.add_provider_for_screen (screen, provider, 600) # GTK_STYLE_PROVIDER_PRIORITY_APPLICATION
 
-class ChangeColorFolder(ChangeFolderColorBase, GObject.GObject, Nemo.MenuProvider, Nemo.NameAndDescProvider):
+class ChangeFolderColor(ChangeFolderColorBase, GObject.GObject, Nemo.MenuProvider, Nemo.NameAndDescProvider):
     def __init__(self):
+        super().__init__()
+
         logger.info("Initializing folder-color-switcher extension...")
         locale.setlocale(locale.LC_ALL, '')
         gettext.bindtextdomain('folder-color-switcher')
         gettext.textdomain('folder-color-switcher')
 
         self.SEPARATOR = u'\u2015' * 4
-        self.settings = Gio.Settings.new("org.cinnamon.desktop.interface")
-        self.settings.connect("changed::icon-theme", self.on_theme_changed)
-        self.on_theme_changed(None, None)
-
-        self.nemo_settings = Gio.Settings.new("org.nemo.preferences")
-        self.nemo_settings.connect("changed::ignore-view-metadata", self.on_ignore_view_metadata_changed)
-        self.nemo_settings.connect("changed::default-folder-viewer", self.on_default_view_changed)
-        self.on_ignore_view_metadata_changed(None)
-        self.on_default_view_changed(None)
-
-    def on_theme_changed(self, settings, key):
-        self.update_theme(self.settings.get_string("icon-theme"))
-
-    def on_ignore_view_metadata_changed(self, settings, key="ignore-view-metadata"):
-        ChangeFolderColorBase.ignore_view_metadata = self.nemo_settings.get_boolean(key)
-
-    def on_default_view_changed(self, settings, key="default-folder-viewer"):
-        ChangeFolderColorBase.default_view = self.nemo_settings.get_string(key)
 
     def menu_activate_cb(self, menu, color, folders):
-        self.set_folder_icons(color, folders)
+        self.set_folder_colors(folders, color)
 
     def get_background_items(self, window, current_folder):
         logger.debug("Current folder is: " + current_folder.get_name())
-        ChangeFolderColorBase.current_directory = current_folder.get_location()
+        self.current_directory = current_folder.get_location()
         return
 
     def get_name_and_desc(self):
@@ -550,7 +397,7 @@ class ChangeColorFolder(ChangeFolderColorBase, GObject.GObject, Nemo.MenuProvide
         if not directories_selected:
             return
 
-        supported_colors = self.theme.get_supported_colors(directories)
+        supported_colors = self.themeset.get_available_colors()
 
         if supported_colors:
             logger.debug("At least one color supported: creating menu entry")

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -296,7 +296,6 @@ class ChangeFolderColorBase(object):
             # get Gio.File object
             directory = folder.get_location()
             path = directory.get_path()
-            info = directory.query_info('metadata::custom-icon', 0, None)
 
             if color:
                 icon_uri = default_folder_icon_uri
@@ -306,13 +305,10 @@ class ChangeFolderColorBase(object):
                     icon_uri = self.themeset.get_icon_uri_for_color_size_and_scale(icon_name, color, icon_size, 1)
 
                 if icon_uri:
-                    info.set_attribute_string('metadata::custom-icon', icon_uri)
+                    directory.set_attribute_string('metadata::custom-icon', icon_uri, 0, None)
             else:
                 # A color of None unsets the custom-icon
-                info.set_attribute('metadata::custom-icon', Gio.FileAttributeType.INVALID, 0)
-
-            # Write changes
-            directory.set_attributes_from_info(info, 0, None)
+                directory.set_attribute('metadata::custom-icon', Gio.FileAttributeType.INVALID, 0, 0, None)
 
             # Touch the directory to make Nemo/Caja re-render its icons
             subprocess.call(["touch", path])

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -246,6 +246,13 @@ class ChangeFolderColorBase(object):
 
     def get_current_view_icon_size(self):
         # get the folder where we are currently in
+        if not self.current_directory \
+                or self.current_directory.get_uri_scheme() == 'x-nemo-desktop':
+            # when selecting files on the desktop -> special URI ('x-nemo-desktop:///')
+            # we could somehow read the icon size level in ~/.config/desktop-metadata and map it.
+            # but as workaround use the default size
+            return 64
+
         info = self.current_directory.query_info('metadata::*', 0, None)
         meta_view = info.get_attribute_string('metadata::nemo-default-view')
 

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -221,7 +221,8 @@ class ChangeFolderColorBase(object):
     def on_default_view_changed(self, settings, key="default-folder-viewer"):
         self.default_view = self.nemo_settings.get_string(key)
 
-    def get_default_view_zoom_level(self, view="icon-view"):
+    @staticmethod
+    def get_default_view_zoom_level(view="icon-view"):
         zoom_lvl_string = Gio.Settings.new("org.nemo.%s" % view).get_string("default-zoom-level")
         return ChangeFolderColorBase.ZOOM_LEVELS[zoom_lvl_string]
 
@@ -229,8 +230,8 @@ class ChangeFolderColorBase(object):
         zoom_lvl_index = self.get_default_view_zoom_level(self.default_view)
         return ChangeFolderColorBase.ZOOM_LEVEL_ICON_SIZES[self.default_view][zoom_lvl_index]
 
-    def get_folder_icon_name(self, directory):
-        logger.debug("get_folder_icon_name: %s", directory)
+    @staticmethod
+    def get_folder_icon_name(directory):
         return ChangeFolderColorBase.KNOWN_DIRECTORIES.get(directory, 'folder')
 
     def get_desired_icon_size(self):

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -85,7 +85,6 @@ class ColoredIconThemeSet:
         'mate': 'Beige',
         'oxygen': 'Blue'
     })
-    logger.debug("Known themes are: %s" % KNOWN_THEMES)
 
     def __init__(self):
         self.availableColoredIconThemes = {}
@@ -161,7 +160,7 @@ class ColoredIconThemeSet:
                 logger.debug("Found icon at URI: %s", uri)
                 return uri
 
-        logger.warning('No icon "%s" found for color "%s", size %i and scale %i', icon_name, color, size, scale)
+        logger.debug('No icon "%s" found for color "%s", size %i and scale %i', icon_name, color, size, scale)
         return None
 
 
@@ -354,6 +353,8 @@ class ChangeFolderColor(ChangeFolderColorBase, GObject.GObject, Nemo.MenuProvide
         locale.setlocale(locale.LC_ALL, '')
         gettext.bindtextdomain('folder-color-switcher')
         gettext.textdomain('folder-color-switcher')
+
+        logger.debug("Known themes are: %s", ', '.join(list(ColoredIconThemeSet.KNOWN_THEMES.keys())))
 
     def menu_activate_cb(self, menu, color, folders):
         self.set_folder_colors(folders, color)

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -134,8 +134,7 @@ class ColoredIconThemeSet:
 
         for color in COLORS:
             it = Gtk.IconTheme.new()
-            it.set_custom_theme(
-            	'%s-%s' % (self.currentBaseIconThemeName, color))
+            it.set_custom_theme('%s-%s' % (self.currentBaseIconThemeName, color))
 
             # check if the default 'folder' icon is available for the given color (size: 32).
             # HACK: to ignore fallback icons, check that the base theme name is included in the icon path

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -17,14 +17,10 @@
 # along with Folder Color; if not, see http://www.gnu.org/licenses
 # for more information.
 
-import os, gettext, locale, collections, re
-import subprocess
-try:
-	# Python2 (Mint 19)
-	import ConfigParser as configparser
-except:
-	# Python 3 (Mint 19.1)
-	import configparser
+import os, gettext, locale, collections, re, subprocess, gi
+
+gi.require_version('Gtk', '3.0')
+gi.require_version('Nemo', '3.0')
 
 from gi.repository import Nemo, GObject, Gio, GLib, Gtk, Gdk
 _ = gettext.gettext

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -283,7 +283,7 @@ class ChangeFolderColorBase(object):
     def set_folder_colors(self, folders, color):
         if color:
             icon_size = self.get_desired_icon_size()
-            default_folder_icon_uri = self.themeset.get_icon_uri_for_color_size_and_scale('folder', color, icon_size, 1)
+            default_folder_icon_uri = self.themeset.get_icon_uri_for_color_size_and_scale('folder', color, icon_size, self.scale_factor)
 
             if not default_folder_icon_uri:
                 return
@@ -301,7 +301,7 @@ class ChangeFolderColorBase(object):
                 icon_name = self.get_folder_icon_name(path)
 
                 if icon_name != 'folder':
-                    icon_uri = self.themeset.get_icon_uri_for_color_size_and_scale(icon_name, color, icon_size, 1)
+                    icon_uri = self.themeset.get_icon_uri_for_color_size_and_scale(icon_name, color, icon_size, self.scale_factor)
 
                 if icon_uri:
                     directory.set_attribute_string('metadata::custom-icon', icon_uri, 0, None)
@@ -357,6 +357,8 @@ class ChangeFolderColor(ChangeFolderColorBase, GObject.GObject, Nemo.MenuProvide
         logger.debug("Known themes are: %s", ', '.join(list(ColoredIconThemeSet.KNOWN_THEMES.keys())))
 
     def menu_activate_cb(self, menu, color, folders):
+        # get scale factor from the clicked menu widget (for Hi-DPI)
+        self.scale_factor = menu.get_scale_factor()
         self.set_folder_colors(folders, color)
 
     def get_background_items(self, window, current_folder):


### PR DESCRIPTION
Use existing functions in Gtk instead of:
* walking directories
* parsing index.theme files
* other hacky string concat stuff..

Fixes:
* #22 (Mint-Y-Dark icons)
* folders on desktop can't be colored