### PR TITLE
Get correct theme on Mate

### DIFF
--- a/usr/share/caja-python/extensions/caja-folder-color-switcher.py
+++ b/usr/share/caja-python/extensions/caja-folder-color-switcher.py
@@ -260,7 +260,7 @@ class ChangeColorFolder(ChangeFolderColorBase, GObject.GObject, Caja.MenuProvide
         if not directories_selected:
             return
 
-        icon_theme_name = Gio.Settings.new("org.cinnamon.desktop.interface").get_string("icon-theme")
+        icon_theme_name = Gio.Settings.new("org.mate.interface").get_string("icon-theme")
         if icon_theme_name in self.styles:
             icon_themes = self.styles[icon_theme_name]["icon-themes"]
             locale.setlocale(locale.LC_ALL, '')


### PR DESCRIPTION
Caja colour switcher is incorrectly getting the active Cinnamon theme and not the Mate one.

Fixes issue specified here
https://github.com/linuxmint/mint21.2-beta/issues/17