### PR TITLE
do not change folder modification time

### DIFF
--- a/usr/share/caja-python/extensions/caja-folder-color-switcher.py
+++ b/usr/share/caja-python/extensions/caja-folder-color-switcher.py
@@ -7,6 +7,7 @@ import json
 import locale
 import os
 import re
+import subprocess
 
 gi.require_version('Gtk', '3.0')
 gi.require_version('Caja', '2.0')
@@ -215,8 +216,10 @@ class ChangeFolderColorBase(object):
                 # A color of None unsets the custom-icon
                 directory.set_attribute('metadata::custom-icon', Gio.FileAttributeType.INVALID, 0, 0, None)
 
-            # update the directory's modified date to make Nemo/Caja re-render its icon
-            os.utime(path, None)
+            # touch the folder (to force Nemo/Caja to re-render its icon)
+            returncode = subprocess.call(['touch', '-r', path, path])
+            if returncode != 0:
+                subprocess.call(['touch', path])
 
 class ChangeColorFolder(ChangeFolderColorBase, GObject.GObject, Caja.MenuProvider):
     def __init__(self):

--- a/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
+++ b/usr/share/nemo-python/extensions/nemo-folder-color-switcher.py
@@ -7,6 +7,7 @@ import json
 import locale
 import os
 import re
+import subprocess
 
 gi.require_version('Gtk', '3.0')
 gi.require_version('Nemo', '3.0')
@@ -238,8 +239,10 @@ class ChangeFolderColorBase(object):
                 # A color of None unsets the custom-icon
                 directory.set_attribute('metadata::custom-icon', Gio.FileAttributeType.INVALID, 0, 0, None)
 
-            # update the directory's modified date to make Nemo/Caja re-render its icon
-            os.utime(path, None)
+            # touch the folder (to force Nemo/Caja to re-render its icon)
+            returncode = subprocess.call(['touch', '-r', path, path])
+            if returncode != 0:
+                subprocess.call(['touch', path])
 
 
 css_colors = b"""


### PR DESCRIPTION
Changing the emblems on a folder doesn't change its modification time, so changing the color of a folder shouldn't change it either. It's bothered me for a long time, and I finally sat down and worked out how to fix it.

The changed code is copied from [nemo-emblems](https://github.com/linuxmint/nemo-extensions/blob/6817b420996a896f947b3acfce6747562c88ea5b/nemo-emblems/nemo-extension/nemo-emblems.py#L162).

I use Cinnamon, not MATE, so I only tested the Nemo plugin, but it's the same in the Caja plugin so it should work.